### PR TITLE
change udunits2 for RMP to udunits2-dev

### DIFF
--- a/sysreqs/libudunits2.json
+++ b/sysreqs/libudunits2.json
@@ -4,7 +4,7 @@
     "platforms": {
       "DEB": "libudunits2-dev",
       "OSX/brew": "udunits",
-      "RPM": "udunits2-dev"
+      "RPM": "udunits2-devel"
     }
   }
 }

--- a/sysreqs/libudunits2.json
+++ b/sysreqs/libudunits2.json
@@ -4,7 +4,7 @@
     "platforms": {
       "DEB": "libudunits2-dev",
       "OSX/brew": "udunits",
-      "RPM": "udunits2"
+      "RPM": "udunits2-dev"
     }
   }
 }


### PR DESCRIPTION
see https://apps.fedoraproject.org/packages/udunits2-devel/ 

comes from build failure on fedora here https://builder.r-hub.io/status/geojsonio_0.3.0.tar.gz-38868a445eb646cf9ff14eaf717a5b5d