### PR TITLE
Fix imagemagick brew name

### DIFF
--- a/sysreqs/magick++.json
+++ b/sysreqs/magick++.json
@@ -3,7 +3,7 @@
     "sysreqs": "Magick++",
     "platforms": {
       "DEB": "libmagick++-dev",
-      "OSX/brew": "imagemagick",
+      "OSX/brew": "imagemagick@6",
       "RPM": "ImageMagick-c++-devel"
     }
   }


### PR DESCRIPTION
upstream formula has renamed to https://github.com/Homebrew/homebrew-core/blob/master/Formula/imagemagick@6.rb