### PR TITLE
Add SAGA GIS

### DIFF
--- a/sysreqs/saga.json
+++ b/sysreqs/saga.json
@@ -1,0 +1,8 @@
+{
+  "saga": {
+    "sysreqs": "/SAGA GIS/",
+    "platforms": {
+      "DEB": "saga"
+    }
+  }
+}


### PR DESCRIPTION
Needed by the R package `RSAGA`: https://cran.r-project.org/package=RSAGA this adds the `saga` Debian package system dependency: https://packages.debian.org/en/saga

The `SystemRequirements` already contains "SAGA GIS (2.3.1 LTS - 6.2.0)" which AFAICT should be matched by the regex used in `syseqs`.

@pat-s @jannes-m @be-marc : FYI

