### PR TITLE
rename to protobuf3 and remove sudo from installer

### DIFF
--- a/scripts/protobuf-installer.sh
+++ b/scripts/protobuf-installer.sh
@@ -5,5 +5,5 @@ unzip protobuf-cpp-3.5.1.zip -d proto
 cd proto/protobuf-3.5.1/
 ./configure
 make
-sudo make install
-sudo ldconfig
+make install
+ldconfig

--- a/sysreqs/protobuf3.json
+++ b/sysreqs/protobuf3.json
@@ -1,6 +1,6 @@
 {
-  "protobuf3-compiler": {
-    "sysreqs": ["protobuf3-compiler"],
+  "protobuf3": {
+    "sysreqs": ["protobuf3"],
     "platforms": {
       "DEB": {"script": "protobuf-installer.sh"},
       "RPM": {"script": "protobuf-installer.sh"},


### PR DESCRIPTION
compilation went fine with make, but I think we can't sudo within docker, thats why I am removing it.
Also renamed to protobuf3, since this install protobuf compiler and runtime library.