### PR TITLE
add word boundary to udunits requirement

### DIFF
--- a/sysreqs/udunits.json
+++ b/sysreqs/udunits.json
@@ -1,6 +1,6 @@
 {
   "udunits": {
-    "sysreqs": "udunits",
+    "sysreqs": "/\\budunits\\b/",
     "platforms": {
        "DEB": "udunits",
        "OSX/brew": "udunits",


### PR DESCRIPTION
Currently https://sysreqs.r-hub.io/pkg/units returns

```json
[
{
"udunits": {
"sysreqs": "udunits",
"platforms": {
"DEB": "udunits",
"OSX/brew": "udunits",
"RPM": "udunits"
}
}
},
{
"libudunits2": {
"sysreqs": "/\\budunits-2\\b/",
"platforms": {
"DEB": "libudunits2-dev",
"OSX/brew": "udunits",
"RPM": "udunits2-devel"
}
}
}
]
```

which incorrectly includes `udunits`, a package that does not exists in the current Debian repositories:

```
$ docker run --rm -it rocker/r-base /bin/bash
root@a7152971d51e:/# apt-get update && apt-get -y update && apt-get install udunits
Get:1 http://cdn-fastly.deb.debian.org/debian sid InRelease [233 kB]
Get:2 http://cdn-fastly.deb.debian.org/debian testing InRelease [150 kB]       
Get:3 http://cdn-fastly.deb.debian.org/debian sid/main amd64 Packages [8,233 kB]
Get:4 http://cdn-fastly.deb.debian.org/debian testing/main amd64 Packages [7,576 kB]
Fetched 16.2 MB in 3s (5,292 kB/s)                         
Reading package lists... Done
Hit:1 http://cdn-fastly.deb.debian.org/debian testing InRelease
Hit:2 http://cdn-fastly.deb.debian.org/debian sid InRelease
Reading package lists... Done
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package udunits
root@a7152971d51e:/# 
```

I guest this is because `udunits` also matches the requirement

```
SystemRequirements: udunits-2
```

in the [`DESCRIPTION`](https://github.com/r-quantities/units/blob/master/DESCRIPTION#L35) file of `units`. Adding word boundaries should fix this.
