### PR TITLE
second attempt at regex for units pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ in their `SystemRequirements` fields.
 
 Some notes:
 * The `sysreqs` field can be a string or array, and its entries can be fixed
-  strings or regular expressions (when starting and ending with a forward slash). [Example of a list `sysreqs` field](https://github.com/r-hub/sysreqsdb/blob/9c0acc932a11b1eb9f1600e27ca39a4d7deb0425/sysreqs/cairo.json#L3), [example of a `sysreqs` field with a regular expression](https://github.com/r-hub/sysreqsdb/blob/9c0acc932a11b1eb9f1600e27ca39a4d7deb0425/sysreqs/imagemagick.json#L3).
+  strings or regular expressions (when starting and ending with a forward slash, only [JavaScript RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) are supported. [Example of a list `sysreqs` field](https://github.com/r-hub/sysreqsdb/blob/9c0acc932a11b1eb9f1600e27ca39a4d7deb0425/sysreqs/cairo.json#L3), [example of a `sysreqs` field with a regular expression](https://github.com/r-hub/sysreqsdb/blob/9c0acc932a11b1eb9f1600e27ca39a4d7deb0425/sysreqs/imagemagick.json#L3).
 * Not all platforms have the same information, For `DEB` based Linux
   flavours (Debian, Ubuntu, etc.) packages that can be installed via the
   host package manager are listed: [`DEB` line example](https://github.com/r-hub/sysreqsdb/blob/9c0acc932a11b1eb9f1600e27ca39a4d7deb0425/sysreqs/cmake.json#L5). For Windows, typically URLs that have

--- a/sysreqs/udunits.json
+++ b/sysreqs/udunits.json
@@ -1,6 +1,6 @@
 {
   "udunits": {
-    "sysreqs": "/\\budunits\\b/",
+    "sysreqs": "/(?:[^-])\\budunits\\b(?![-_.])/",
     "platforms": {
        "DEB": "udunits",
        "OSX/brew": "udunits",


### PR DESCRIPTION
this would work a bit better with [support for lookbehinds](https://www.stefanjudis.com/today-i-learned/the-complicated-syntax-of-lookaheads-in-javascript-regular-expressions/#lookaheads-will-have-company-from-lookbehinds-soon), but that depends on the used JavaScript version for https://github.com/r-hub/sysreqs.app

The current regex matches whitespace before the expression:

![image](https://user-images.githubusercontent.com/1325054/44580863-e3e4eb00-a79b-11e8-90e3-fd17b3d1d65d.png)

