### PR TITLE
json for library nlopt

### DIFF
--- a/sysreqs/nlopt.json
+++ b/sysreqs/nlopt.json
@@ -1,0 +1,10 @@
+{
+  "nlopt": {
+    "sysreqs": "nlopt",
+    "platforms": {
+      "DEB": "libnlopt-dev",
+      "OSX/brew": "nlopt",
+      "RPM": "NLopt-devel"
+    }
+  }
+}


### PR DESCRIPTION
not sure: either 'NLopt' or 'nlopt' for the sysreqs field ?