### PR TITLE
Add support for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ Distributions using `rpm` package format:
 * Fedora Linux (recent releases)
 * RedHat and CentOS Linux (recent releases)
 
-Non-native package formats;
+Distributions using the `PKGBUILD` package format:
+* Arch Linux
+
+Non-native package formats:
 * HomeBrew package manager on MacOS
 * Pacman/Rtools on Windows (forthcoming)
 

--- a/platforms/linux-x86_64-arch-clang.json
+++ b/platforms/linux-x86_64-arch-clang.json
@@ -1,0 +1,7 @@
+{
+    "id": "linux-x86_64-arch-clang",
+    "name": "PKGBUILD",
+    "distribution": "Arch",
+    "release": "2019.04.01",
+    "install-commands": "pacman -Syu && pacman -S --noconfirm ${sysreqs}"
+}

--- a/platforms/linux-x86_64-arch-gcc.json
+++ b/platforms/linux-x86_64-arch-gcc.json
@@ -1,5 +1,5 @@
 {
-    "id": "linux-x86_64-arch-clang",
+    "id": "linux-x86_64-arch-gcc",
     "name": "PKGBUILD",
     "distribution": "Arch",
     "release": "2019.04.01",

--- a/scripts/pandoc-installer.sh
+++ b/scripts/pandoc-installer.sh
@@ -15,22 +15,26 @@ if uname > /dev/null && [ $(uname) == 'Darwin' ]; then
 elif uname > /dev/null && [ $(uname) == 'Linux' ] ;then
     >&2 echo "Linux detected"
     if [ -f /etc/debian_version ]; then
-	>&2 echo "DEB distro detected"
-	distro=debian
-	arch=$(uname -p)
+        >&2 echo "DEB distro detected"
+        distro=debian
+        arch=$(uname -p)
     elif [ -f /etc/redhat-release ]; then
-	>&2 echo "RPM distro detected"
-	distro=rpm
-	arch=$(uname -p)
+        >&2 echo "RPM distro detected"
+        distro=rpm
+        arch=$(uname -p)
+    elif [ -f "/etc/arch-release" ]; then
+        >&2 echo "PKGBUILD distro detected"
+        distro=arch
+        arch=$(uname -p)
     else
-	>&2 echo "Unknown distro, try DEB"
-	distro=debian
-	arch=$(uname -p)
+        >&2 echo "Unknown distro, try DEB"
+        distro=debian
+        arch=$(uname -p)
     fi
 
     # Some Docker images report unknown, try to use 64 bit then
     if [ "$arch" == "unknown" ]; then
-	arch="x86_64"
+        arch="x86_64"
     fi
 
     PANDOC="${URL}/linux/${distro}/${arch}/pandoc"

--- a/sysreqs/apparmor.json
+++ b/sysreqs/apparmor.json
@@ -2,7 +2,8 @@
   "apparmor": {
     "sysreqs": "/apparmor/i",
     "platforms": {
-      "DEB": "libapparmor-dev"
+      "DEB": "libapparmor-dev",
+      "PKGBUILD": "apparmor"
     }
   }
 }

--- a/sysreqs/atk.json
+++ b/sysreqs/atk.json
@@ -1,11 +1,11 @@
 {
-    "atk": {
+  "atk": {
     "sysreqs": "/\\bATK\\b/",
     "platforms": {
-        "DEB": "libatk1.0-dev",
-        "OSX/brew": "atk",
-        "PKGBUILD": "atk",
-        "RPM": "atk-devel"
+      "DEB": "libatk1.0-dev",
+      "OSX/brew": "atk",
+      "PKGBUILD": "atk",
+      "RPM": "atk-devel"
     }
-    }
+  }
 }

--- a/sysreqs/atk.json
+++ b/sysreqs/atk.json
@@ -1,10 +1,11 @@
 {
     "atk": {
-	"sysreqs": "/\\bATK\\b/",
-	"platforms": {
-	    "DEB": "libatk1.0-dev",
-	    "OSX/brew": "atk",
-	    "RPM": "atk-devel"
-	}
+    "sysreqs": "/\\bATK\\b/",
+    "platforms": {
+        "DEB": "libatk1.0-dev",
+        "OSX/brew": "atk",
+        "PKGBUILD": "atk",
+        "RPM": "atk-devel"
+    }
     }
 }

--- a/sysreqs/automake.json
+++ b/sysreqs/automake.json
@@ -4,7 +4,8 @@
     "platforms": {
       "DEB": "automake",
       "RPM": "automake",
-      "OSX/brew": "automake"
+      "OSX/brew": "automake",
+      "PKGBUILD": "automake"
     }
   }
 }

--- a/sysreqs/bayescan.json
+++ b/sysreqs/bayescan.json
@@ -2,6 +2,7 @@
   "bayescan": {
     "sysreqs": "/Bayescan/",
     "platforms": {
+        "PKGBUILD": "bayescan"
     }
   }
 }

--- a/sysreqs/bowtie2.json
+++ b/sysreqs/bowtie2.json
@@ -3,7 +3,8 @@
     "sysreqs": "bowtie2",
     "platforms": {
       "DEB": "bowtie2",
-      "OSX/brew": "homebrew/science/bowtie2"
+      "OSX/brew": "homebrew/science/bowtie2",
+      "PKGBUILD": "bowtie2"
     }
   }
 }

--- a/sysreqs/bwidget.json
+++ b/sysreqs/bwidget.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "bwidget",
       "OSX/brew": "TODO",
+      "PKGBUILD": "bwidget",
       "RPM": "bwidget"
     }
   }

--- a/sysreqs/cairo.json
+++ b/sysreqs/cairo.json
@@ -7,6 +7,7 @@
         "buildtime": "libcairo2-dev"
       },
       "OSX/brew": "cairo",
+      "PKGBUILD": "cairo",
       "RPM": {
         "runtime": "cairo",
         "buildtime": "cairo-devel"

--- a/sysreqs/cmake.json
+++ b/sysreqs/cmake.json
@@ -5,6 +5,7 @@
       "DEB": "cmake",
       "RPM": "cmake",
       "OSX/brew": "cmake",
+      "PKGBUILD": "cmake",
       "Windows": {
         "32bit": [
           "https://cmake.org/files/v3.9/cmake-3.9.0-win32-x86.zip"

--- a/sysreqs/coin-or-clp.json
+++ b/sysreqs/coin-or-clp.json
@@ -2,7 +2,8 @@
   "coin-or-clp": {
     "sysreqs": "/COIN-OR Clp/i",
     "platforms": {
-      "DEB": "coinor-clp"
+      "DEB": "coinor-clp",
+      "PKGBUILD": "coinor-csdp"
     }
   }
 }

--- a/sysreqs/cxx11.json
+++ b/sysreqs/cxx11.json
@@ -5,6 +5,7 @@
       "DEB": null,
       "OSX/brew": null,
       "RPM": null,
+      "PKGBUILD": null,
       "Windows": null
     },
     "comment": "We don't do anything special for C++-11"

--- a/sysreqs/dcraw.json
+++ b/sysreqs/dcraw.json
@@ -4,7 +4,8 @@
     "platforms": {
       "DEB": "dcraw",
       "RPM": "dcraw",
-      "OSX/brew": "dcraw"
+      "OSX/brew": "dcraw",
+       "PKGBUILD": "dcraw"
     }
   }
 }

--- a/sysreqs/exiftool.json
+++ b/sysreqs/exiftool.json
@@ -4,6 +4,7 @@
     "platforms": {
        "DEB": "libimage-exiftool-perl",
        "OSX/brew": "exiftool",
+       "PKGBUILD": "perl-image-exiftool",
        "RPM": null
     }
   }

--- a/sysreqs/ffmpeg.json
+++ b/sysreqs/ffmpeg.json
@@ -3,7 +3,8 @@
     "sysreqs": "/FFmpeg/",
     "platforms": {
       "DEB": "ffmpeg",
-      "OSX/brew": "ffmpeg"
+      "OSX/brew": "ffmpeg",
+      "PKGBUILD": "ffmpeg"
     }
   }
 }

--- a/sysreqs/fftw.json
+++ b/sysreqs/fftw.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libfftw3-dev",
       "OSX/brew": "fftw",
+      "PKGBUILD": "fftw",
       "RPM": "fftw-devel"
     }
   }

--- a/sysreqs/fftw3.json
+++ b/sysreqs/fftw3.json
@@ -6,6 +6,7 @@
         "runtime": "libfftw3-3",
         "buildtime": "libfftw3-dev"
       },
+      "PKGBUILD": "fftw",
       "RPM": "fftw-devel"
     }
   }

--- a/sysreqs/freetype.json
+++ b/sysreqs/freetype.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libfreetype6-dev",
       "OSX/brew": "freetype",
+      "PKGBUILD": "freetype2",
       "RPM": "freetype-devel"
     }
   }

--- a/sysreqs/gdal.json
+++ b/sysreqs/gdal.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "gdal-bin",
       "OSX/brew": "gdal",
+      "PKGBUILD": "gdal",
       "RPM": "gdal"
     }
   }

--- a/sysreqs/ggobi.json
+++ b/sysreqs/ggobi.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "ggobi",
       "OSX/brew": "ggobi",
+      "PKGBUILD": "ggobi",
       "RPM": "ggobi"
     }
   }

--- a/sysreqs/git.json
+++ b/sysreqs/git.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "git-core",
       "RPM": "git",
+      "PKGBUILD": "git",
       "OSX/brew": "git"
     }
   }

--- a/sysreqs/glib.json
+++ b/sysreqs/glib.json
@@ -4,6 +4,7 @@
 	"platforms": {
 	    "DEB": "libglib2.0-dev",
 	    "OSX/brew": "glib",
+        "PKGBUILD": "glib2",
 	    "RPM": "glib2-devel"
 	}
     }

--- a/sysreqs/glu.json
+++ b/sysreqs/glu.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libglu1-mesa-dev",
       "OSX/brew": null,
+      "PKGBUILD": "glu",
       "RPM": "mesa-libGLU-devel"
     }
   }

--- a/sysreqs/gnumake.json
+++ b/sysreqs/gnumake.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "make",
       "OSX/brew": null,
+      "PKGBUILD": "make",
       "RPM": "make"
     }
   }

--- a/sysreqs/gpgme.json
+++ b/sysreqs/gpgme.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libgpgme11-dev haveged",
       "OSX/brew": "gpgme",
+      "PKGBUILD": "gpgme",
       "RPM": "gpgme-devel haveged"
     }
   }

--- a/sysreqs/gtkplus.json
+++ b/sysreqs/gtkplus.json
@@ -4,6 +4,7 @@
 	"platforms": {
 	    "DEB": "libgtk2.0-dev",
 	    "OSX/brew": "gtk+",
+        "PKGBUILD": "gtk2",
 	    "RPM": "gtk2-devel"
 	}
     }

--- a/sysreqs/hdf5.json
+++ b/sysreqs/hdf5.json
@@ -4,6 +4,7 @@
         "platforms": {
             "DEB": "libhdf5-dev",
             "OSX/brew": "hdf5",
+            "PKGBUILD": "hdf5",
             "RPM": "hdf5-devel"
         }
     }

--- a/sysreqs/hiredis.json
+++ b/sysreqs/hiredis.json
@@ -4,6 +4,7 @@
         "platforms": {
             "DEB": "libhiredis-dev",
             "OSX/brew": "hiredis",
+            "PKGBUILD": "hiredis",
             "RPM": "libhiredis-devel"
         }
     }

--- a/sysreqs/imagej.json
+++ b/sysreqs/imagej.json
@@ -4,6 +4,7 @@
     "platforms": {
        "DEB": "imagej",
        "OSX/brew": "imagej",
+       "PKGBUILD": "imagej",
        "RPM": "imagej"
     }
   }

--- a/sysreqs/imagemagick.json
+++ b/sysreqs/imagemagick.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "imagemagick",
       "OSX/brew": "imagemagick@6",
+      "PKGBUILD": "imagemagick",
       "RPM": "ImageMagick"
     }
   }

--- a/sysreqs/itk.json
+++ b/sysreqs/itk.json
@@ -4,7 +4,8 @@
     "platforms": {
       "DEB": "insighttoolkit4-python libinsighttoolkit4-dev",
       "RPM": "InsightToolkit-devel InsightToolkit-vtk-devel",
-      "OSX/brew": "insighttoolkit"
+      "OSX/brew": "insighttoolkit",
+      "PKGBUILD": "insight-toolkit"
     }
   }
 }

--- a/sysreqs/jags.json
+++ b/sysreqs/jags.json
@@ -3,7 +3,8 @@
     "sysreqs": "/jags\\b/i",
     "platforms": {
       "DEB": "jags",
-      "OSX/brew": "jags"
+      "OSX/brew": "jags",
+      "PKGBUILD": "jags"
     }
   }
 }

--- a/sysreqs/java.json
+++ b/sysreqs/java.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "openjdk-7-jre-headless",
       "OSX/brew": null,
+      "PKGBUILD": "jre-openjdk-headless",
       "RPM": "java-1.8.0-openjdk"
     }
   }

--- a/sysreqs/libarchive.json
+++ b/sysreqs/libarchive.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libarchive-dev",
       "OSX/brew": "libarchive",
+      "PKGBUILD": "libarchive",
       "RPM": "libarchive-devel",
       "CSW": "libarchive_dev"
     }

--- a/sysreqs/libav.json
+++ b/sysreqs/libav.json
@@ -4,6 +4,7 @@
     "platforms": {
        "DEB": "libav-tools",
        "OSX/brew": "libav",
+       "PKGBUILD": "gst-libav",
        "RPM": null
     }
   }

--- a/sysreqs/libbi.json
+++ b/sysreqs/libbi.json
@@ -4,6 +4,7 @@
     "platforms": {
        "DEB": null,
        "OSX/brew": "libbi",
+       "PKGBUILD": null,
        "RPM": null
     }
   }

--- a/sysreqs/libbsd.json
+++ b/sysreqs/libbsd.json
@@ -3,6 +3,7 @@
     "sysreqs": "libbsd",
     "platforms": {
       "DEB": "libbsd-dev",
+      "PKGBUILD": "libbsd",
       "RPM": "libbsd-devel"
     }
   }

--- a/sysreqs/libcurl.json
+++ b/sysreqs/libcurl.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libcurl4-openssl-dev",
       "OSX/brew": null,
+      "PKGBUILD": "curl",
       "RPM": "libcurl-devel"
     }
   }

--- a/sysreqs/libdb_stl.json
+++ b/sysreqs/libdb_stl.json
@@ -16,7 +16,8 @@
           "buildtime": "libdb5.3-stl"
         }
       ],
-      "OSX/brew": "berkeley-db"
+      "OSX/brew": "berkeley-db",
+      "PKGBUILD": "db"
     }
   }
 }

--- a/sysreqs/libgdal.json
+++ b/sysreqs/libgdal.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libgdal-dev",
       "OSX/brew": "gdal",
+      "PKGBUILD": "gdal",
       "RPM": "gdal-devel"
     }
   }

--- a/sysreqs/libgeos.json
+++ b/sysreqs/libgeos.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libgeos-dev libgeos++-dev",
       "OSX/brew": "geos",
+      "PKGBUILD": "geos",
       "RPM": "geos-devel"
     }
   }

--- a/sysreqs/libgmp.json
+++ b/sysreqs/libgmp.json
@@ -6,6 +6,7 @@
         "runtime": "libgmp10",
         "buildtime": "libgmp-dev"
       },
+      "PKGBUILD": "gmp",
       "OSX/brew": "gmp"
     }
   }

--- a/sysreqs/libgsl.json
+++ b/sysreqs/libgsl.json
@@ -26,6 +26,7 @@
           "buildtime": "libgsl-dev"
         }
       ],
+      "PKGBUILD": "gsl",
       "OSX/brew": "gsl",
       "RPM": {
         "runtime": "gsl",

--- a/sysreqs/libjq.json
+++ b/sysreqs/libjq.json
@@ -5,6 +5,7 @@
     "platforms": {
       "DEB": "libjq-dev",
       "RPM": "jq-devel",
+      "PKGBUILD": "jq",
       "OSX/brew": "jq"
     }
   }

--- a/sysreqs/libmagic.json
+++ b/sysreqs/libmagic.json
@@ -3,6 +3,7 @@
     "sysreqs": "libmagic",
     "platforms": {
        "DEB": "libmagic-dev",
+       "PKGBUILD": "file",
        "OSX/brew": "libmagic",
        "RPM": "file-devel"
     }

--- a/sysreqs/libmpfr.json
+++ b/sysreqs/libmpfr.json
@@ -1,11 +1,11 @@
 {
-    "libmpfr": {
+  "libmpfr": {
     "sysreqs": "mpfr",
     "platforms": {
-        "DEB": "libmpfr-dev",
-        "PKGBUILD": "mpfr",
-        "OSX/brew": "mpfr",
-        "RPM": "mpfr-devel"
+      "DEB": "libmpfr-dev",
+      "PKGBUILD": "mpfr",
+      "OSX/brew": "mpfr",
+      "RPM": "mpfr-devel"
     }
-    }
+  }
 }

--- a/sysreqs/libmpfr.json
+++ b/sysreqs/libmpfr.json
@@ -1,10 +1,11 @@
 {
     "libmpfr": {
-	"sysreqs": "mpfr",
-	"platforms": {
-	    "DEB": "libmpfr-dev",
-	    "OSX/brew": "mpfr",
-	    "RPM": "mpfr-devel"
-	}
+    "sysreqs": "mpfr",
+    "platforms": {
+        "DEB": "libmpfr-dev",
+        "PKGBUILD": "mpfr",
+        "OSX/brew": "mpfr",
+        "RPM": "mpfr-devel"
+    }
     }
 }

--- a/sysreqs/libpng.json
+++ b/sysreqs/libpng.json
@@ -3,6 +3,7 @@
     "sysreqs": "/\\blibpng\\b/",
     "platforms": {
       "DEB": "libpng-dev",
+      "PKGBUILD": "libpng",
       "OSX/brew": "libpng",
       "RPM": "libpng-devel"
     }

--- a/sysreqs/libpq.json
+++ b/sysreqs/libpq.json
@@ -3,6 +3,7 @@
     "sysreqs": "libpq",
     "platforms": {
       "DEB": "libpq-dev",
+      "PKGBUILD": "libpqxx",
       "OSX/brew": "libpq",
       "RPM": "postgresql-devel"
     }

--- a/sysreqs/libproj.json
+++ b/sysreqs/libproj.json
@@ -3,6 +3,7 @@
     "sysreqs": ["PROJ.4", "proj.maptools.org"],
     "platforms": {
       "DEB": "libproj-dev",
+      "PKGBUILD": "proj",
       "OSX/brew": "proj",
       "RPM": "proj-devel proj-epsg proj-nad"
     }

--- a/sysreqs/libprotobuf.json
+++ b/sysreqs/libprotobuf.json
@@ -3,6 +3,7 @@
     "sysreqs": "libprotobuf",
     "platforms": {
       "DEB": "libprotobuf-dev",
+      "PKGBUILD": "protobuf",
       "OSX/brew": "protobuf",
       "RPM": "protobuf-devel"
     }

--- a/sysreqs/librsvg2.json
+++ b/sysreqs/librsvg2.json
@@ -3,6 +3,7 @@
     "sysreqs": "librsvg2",
     "platforms": {
       "DEB": "librsvg2-dev",
+      "PKGBUILD": "librsvg",
       "OSX/brew": "librsvg",
       "RPM": "librsvg2-devel"
     }

--- a/sysreqs/libsecret.json
+++ b/sysreqs/libsecret.json
@@ -3,6 +3,7 @@
     "sysreqs": "/\\blibsecret\\b/",
     "platforms": {
       "DEB": "libsecret-1-dev",
+      "PKGBUILD": "libsecret",
       "OSX/brew": "libsecret",
       "RPM": "libsecret-devel"
     }

--- a/sysreqs/libsndfile.json
+++ b/sysreqs/libsndfile.json
@@ -3,6 +3,7 @@
     "sysreqs": "libsndfile",
     "platforms": {
        "DEB": "libsndfile1-dev",
+       "PKGBUILD": "libsndfile",
        "OSX/brew": "libsndfile",
        "RPM": "libsndfile-devel"
     }

--- a/sysreqs/libssh.json
+++ b/sysreqs/libssh.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libssh-dev",
       "RPM": "libssh-devel",
+      "PKGBUILD": "libssh",
       "OSX/brew": "libssh"
     }
   }

--- a/sysreqs/libssh2.json
+++ b/sysreqs/libssh2.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libssh2-1-dev",
       "RPM": "libssh2-devel",
+      "PKGBUILD": "libssh2",
       "OSX/brew": "libssh2"
     }
   }

--- a/sysreqs/libtiff.json
+++ b/sysreqs/libtiff.json
@@ -3,6 +3,7 @@
     "sysreqs": "/\\blibtiff\\b/",
     "platforms": {
       "DEB": "libtiff-dev",
+      "PKGBUILD": "libtiff",
       "OSX/brew": "libtiff",
       "RPM": "libtiff-devel"
     }

--- a/sysreqs/libudunits2.json
+++ b/sysreqs/libudunits2.json
@@ -3,6 +3,7 @@
     "sysreqs": "/\\budunits-2\\b/",
     "platforms": {
       "DEB": "libudunits2-dev",
+      "PKGBUILD": "udunits",
       "OSX/brew": "udunits",
       "RPM": "udunits2-devel"
     }

--- a/sysreqs/libxft.json
+++ b/sysreqs/libxft.json
@@ -6,6 +6,7 @@
         "runtime": "libxft2",
         "buildtime": "libxft-dev"
       },
+      "PKGBUILD": "libxft",
       "RPM": {
         "runtime": "libXft",
         "buildtime": "libXft-devel"

--- a/sysreqs/libxml2.json
+++ b/sysreqs/libxml2.json
@@ -3,6 +3,7 @@
     "sysreqs": "libxml2",
     "platforms": {
        "DEB": "libxml2-dev",
+       "PKGBUILD": "libxml2",
        "OSX/brew": null,
        "RPM": "libxml2-devel"
     }

--- a/sysreqs/libxslt.json
+++ b/sysreqs/libxslt.json
@@ -3,6 +3,7 @@
     "sysreqs": "libxslt",
     "platforms": {
        "DEB": "libxslt1-dev",
+       "PKGBUILD": "libxslt",
        "OSX/brew": "libxslt",
        "RPM": "libxslt-devel"
     }

--- a/sysreqs/magick++.json
+++ b/sysreqs/magick++.json
@@ -3,6 +3,7 @@
     "sysreqs": "Magick++",
     "platforms": {
       "DEB": "libmagick++-dev",
+      "PKGBUILD": "imagemagick",
       "OSX/brew": "imagemagick@6",
       "RPM": "ImageMagick-c++-devel"
     }

--- a/sysreqs/mariadb.json
+++ b/sysreqs/mariadb.json
@@ -3,6 +3,7 @@
     "sysreqs": "MySQL (>=5.6)",
     "platforms": {
       "DEB": ["mysql-server-5.6", "mysql-client-5.6"],
+      "PKGBUILD": "mariadb",
       "OSX/brew": "mysql",
       "RPM": ["mysql-server", "mysql"]
     }

--- a/sysreqs/monetdb.json
+++ b/sysreqs/monetdb.json
@@ -3,6 +3,7 @@
     "sysreqs": "monetdb",
     "platforms": {
        "DEB": "monetdb5-sql",
+      "PKGBUILD": "moneydb",
        "OSX/brew": "monetdb",
        "RPM": "MonetDB-SQL-server5 MonetDB-client"
     }

--- a/sysreqs/mongodb.json
+++ b/sysreqs/mongodb.json
@@ -3,6 +3,7 @@
     "sysreqs": "mongodb",
     "platforms": {
        "DEB": "mongodb",
+       "PKGBUILD": "mongodb",
        "OSX/brew": "mongodb",
        "RPM": "mongodb-org"
     }

--- a/sysreqs/mysql-client.json
+++ b/sysreqs/mysql-client.json
@@ -25,6 +25,7 @@
           "runtime": "libmariadb2"
         }
       ],
+      "PKGBUILD": "mariadb-clients",
       "OSX/brew": "mariadb-connector-c"
     }
   }

--- a/sysreqs/mysql.json
+++ b/sysreqs/mysql.json
@@ -3,6 +3,7 @@
     "sysreqs": "MySQL (>=5.6)",
     "platforms": {
       "DEB": ["mysql-server-5.6", "mysql-client-5.6"],
+      "PKGBUILD": "mysql",
       "OSX/brew": "mysql",
       "RPM": ["mysql-server", "mysql"]
     }

--- a/sysreqs/netcdf4.json
+++ b/sysreqs/netcdf4.json
@@ -3,6 +3,7 @@
 	"sysreqs": "netcdf",
 	"platforms": {
 	    "DEB": "libnetcdf-dev",
+        "PKGBUILD": "netcdf",
 	    "OSX/brew": "netcdf",
 	    "RPM": "netcdf-devel"
 	}

--- a/sysreqs/nvcc.json
+++ b/sysreqs/nvcc.json
@@ -2,7 +2,8 @@
   "nvcc": {
     "sysreqs": "nvcc",
     "platforms": {
-      "DEB": "nvidia-cuda-toolkit"
+      "DEB": "nvidia-cuda-toolkit",
+      "PKGBUILD": "cuda"
     }
   }
 }

--- a/sysreqs/odbc.json
+++ b/sysreqs/odbc.json
@@ -3,6 +3,7 @@
       "sysreqs": "/\\bODBC3?\\b/i",
       "platforms": {
         "DEB": "unixodbc-dev",
+        "PKGBUILD": "unixodbc",
         "OSX/brew": "unixodbc",
         "RPM": "unixODBC-devel"
       }

--- a/sysreqs/opengl.json
+++ b/sysreqs/opengl.json
@@ -3,6 +3,7 @@
     "sysreqs": "OpenGL",
     "platforms": {
       "DEB": "libgl1-mesa-dev",
+      "PKGBUILD": "mesa",
       "OSX/brew": null,
       "RPM": "mesa-libGL-devel"
     }

--- a/sysreqs/openmpi.json
+++ b/sysreqs/openmpi.json
@@ -6,6 +6,7 @@
         "runtime": "libopenmpi1.6",
         "buildtime": "libopenmpi-dev"
       },
+      "PKGBUILD": "openmpi",
       "OSX/brew": "openmpi",
       "RPM": {
         "runtime": "openmpi",

--- a/sysreqs/openssl.json
+++ b/sysreqs/openssl.json
@@ -3,6 +3,7 @@
     "sysreqs": "OpenSSL",
     "platforms": {
       "DEB": "libssl-dev",
+      "PKGBUILD": "openssl",
       "OSX/brew": "openssl@1.1",
       "RPM": "openssl-devel"
     }

--- a/sysreqs/pandoc.json
+++ b/sysreqs/pandoc.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "pandoc pandoc-citeproc",
       "RPM": "pandoc pandoc-citeproc",
+      "PKGBUILD": "pandoc pandoc-citeproc",
       "OSX/brew": "pandoc pandoc-citeproc"
     }
   }

--- a/sysreqs/pango.json
+++ b/sysreqs/pango.json
@@ -3,6 +3,7 @@
 	"sysreqs": "/\\bPango\\b/i",
 	"platforms": {
 	    "DEB": "libpango1.0-dev",
+        "PKGBUILD": "pango",
 	    "OSX/brew": "pango",
 	    "RPM": "pango-devel"
 	}

--- a/sysreqs/pari-gp.json
+++ b/sysreqs/pari-gp.json
@@ -3,6 +3,7 @@
     "sysreqs": "pari-gp",
     "platforms": {
        "DEB": "pari-gp",
+       "PKGBUILD": "pari",
        "OSX/brew": "pari",
        "RPM": "pari-gp"
     }

--- a/sysreqs/pdflatex.json
+++ b/sysreqs/pdflatex.json
@@ -3,6 +3,7 @@
     "sysreqs": "/(PDF)LaTeX/i",
     "platforms": {
       "DEB": "texlive-latex-base",
+      "PKGBUILD": "texlive-core",
       "OSX/brew": null,
       "RPM": "texlive-collection-basic"
     }

--- a/sysreqs/perl.json
+++ b/sysreqs/perl.json
@@ -3,6 +3,7 @@
     "sysreqs": "Perl (>=5)",
     "platforms": {
       "DEB": "perl",
+      "PKGBUILD": "perl",
       "OSX/brew": null,
       "RPM": "perl"
     }

--- a/sysreqs/pkgconfig.json
+++ b/sysreqs/pkgconfig.json
@@ -3,7 +3,6 @@
     "sysreqs": "/pkg(:-|)config/",
     "platforms": {
       "DEB": "pkg-config",
-      "PKGBUILD": "",
       "OSX/brew": "pkg-config",
       "PKGBUILD": "pkgconf",
       "RPM": "pkgconfig"

--- a/sysreqs/pkgconfig.json
+++ b/sysreqs/pkgconfig.json
@@ -3,7 +3,9 @@
     "sysreqs": "/pkg(:-|)config/",
     "platforms": {
       "DEB": "pkg-config",
+      "PKGBUILD": "",
       "OSX/brew": "pkg-config",
+      "PKGBUILD": "pkgconf",
       "RPM": "pkgconfig"
     }
   }

--- a/sysreqs/poppler.json
+++ b/sysreqs/poppler.json
@@ -3,6 +3,7 @@
     "sysreqs": "poppler",
     "platforms": {
       "DEB": "libpoppler-cpp-dev",
+      "PKGBUILD": "poppler",
       "OSX/brew": "poppler",
       "RPM": "poppler-cpp-devel"
     }

--- a/sysreqs/postgresql-client.json
+++ b/sysreqs/postgresql-client.json
@@ -6,6 +6,7 @@
         "runtime": "libpq5",
         "buildtime": "libpq-dev"
       },
+      "PKGBUILD": "libpqxx",
       "OSX/brew": "libpq"
     }
   }

--- a/sysreqs/protobuf-compiler.json
+++ b/sysreqs/protobuf-compiler.json
@@ -3,6 +3,7 @@
     "sysreqs": "protobuf-compiler",
     "platforms": {
       "DEB": "protobuf-compiler libprotoc-dev",
+      "PKGBUILD": "protobuf",
       "OSX/brew": "protobuf",
       "RPM": "protobuf-compiler"
     }

--- a/sysreqs/protobuf3.json
+++ b/sysreqs/protobuf3.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": {"script": "protobuf-installer.sh"},
       "RPM": {"script": "protobuf-installer.sh"},
+      "PKGBUILD": "protobuf",
       "OSX/brew": "protobuf"
     }
   }  

--- a/sysreqs/python.json
+++ b/sysreqs/python.json
@@ -5,6 +5,7 @@
                  "Python (>= 2.4.0)", "Python (>=2.6)", "Python (>= 2.7" ],
     "platforms": {
       "DEB": "python-minimal",
+      "PKGBUILD": "python2",
       "OSX/brew": null,
       "RPM": "python"
     }

--- a/sysreqs/qgis.json
+++ b/sysreqs/qgis.json
@@ -3,6 +3,7 @@
     "sysreqs": "/QGIS/",
     "platforms": {
       "DEB": "qgis",
+      "PKGBUILD": "qgis",
       "OSX/brew": "qgis2"
     }
   }

--- a/sysreqs/redland.json
+++ b/sysreqs/redland.json
@@ -3,6 +3,7 @@
     "sysreqs": ["/redland/", "/librdf/"],
    "platforms": {
       "DEB": "librdf0-dev",
+      "PKGBUILD": "redland",
       "OSX/brew": "redland",
       "RPM": "redland-devel"
     }

--- a/sysreqs/rust.json
+++ b/sysreqs/rust.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "cargo",
       "RPM": "cargo",
+      "PKGBUILD": "rust",
       "OSX/brew": "rust"      
     }
   }

--- a/sysreqs/saga.json
+++ b/sysreqs/saga.json
@@ -3,6 +3,7 @@
     "sysreqs": "/SAGA GIS/",
     "platforms": {
       "DEB": "saga",
+      "PKGBUILD": "saga-gis",
       "OSX/brew": "saga-gis-lts"
     }
   }

--- a/sysreqs/sasl.json
+++ b/sysreqs/sasl.json
@@ -4,6 +4,7 @@
     "platforms": {
        "DEB": "libsasl2-dev",
        "OSX/brew": null,
+       "PKGBUILD": "libsasl",
        "RPM": "cyrus-sasl-devel"
     }
   }

--- a/sysreqs/sodium.json
+++ b/sysreqs/sodium.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libsodium-dev",
       "OSX/brew": "libsodium",
+      "PKGBUILD": "libsodium",
       "RPM": "libsodium-devel"
     }
   }

--- a/sysreqs/swftools.json
+++ b/sysreqs/swftools.json
@@ -3,6 +3,7 @@
     "sysreqs": "/SWF Tools/",
     "platforms": {
       "DEB": "swftools",
+      "PKGBUILD": "swftools",
       "OSX/brew": "swftools"
     }
   }

--- a/sysreqs/tcltk.json
+++ b/sysreqs/tcltk.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": ["tcl8.5", "tk8.6"],
       "OSX/brew": "tcl-tk",
+      "PKGBUILD": ["tcl", "tk"],
       "RPM": ["tcl", "tk"]
     }
   }

--- a/sysreqs/tesseract.json
+++ b/sysreqs/tesseract.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libtesseract-dev libleptonica-dev tesseract-ocr-eng",
       "OSX/brew": "tesseract",
+      "PKGBUILD": "tesseract",
       "RPM": "tesseract-devel leptonica-devel"
     }
   }

--- a/sysreqs/tktable.json
+++ b/sysreqs/tktable.json
@@ -3,6 +3,7 @@
     "sysreqs": ["Tktable", "tktable"],
     "platforms": {
       "DEB": "tk-table",
+      "PKGBUILD": "tktable",
       "RPM": "tktable"
     }
   }

--- a/sysreqs/udunits.json
+++ b/sysreqs/udunits.json
@@ -4,6 +4,7 @@
     "platforms": {
        "DEB": "udunits",
        "OSX/brew": "udunits",
+       "PKGBUILD": "udunits",
        "RPM": "udunits"
     }
   }

--- a/sysreqs/v8.json
+++ b/sysreqs/v8.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libv8-dev",
       "OSX/brew": "v8",
+      "PKGBUILD": "v8",
       "RPM": "v8-314-devel"
     }
   }

--- a/sysreqs/webp.json
+++ b/sysreqs/webp.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libwebp-dev",
       "OSX/brew": "webp",
+      "PKGBUILD": "libwebp",
       "RPM": "libwebp-devel"
     }
   }

--- a/sysreqs/wget.json
+++ b/sysreqs/wget.json
@@ -5,6 +5,7 @@
       "DEB": "wget",
       "RPM": "wget",
       "OSX/brew": "wget",
+      "PKGBUILD": "wget",
       "Windows": {
         "32bit": [
           "http://downloads.sourceforge.net/gnuwin32/wget-1.11.4-1-bin.zip"

--- a/sysreqs/zeromq.json
+++ b/sysreqs/zeromq.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "libzmq3-dev",
       "OSX/brew": "zeromq",
+      "PKGBUILD": "zeromq",
       "RPM": "zeromq-devel"
     }
   }

--- a/sysreqs/zlib.json
+++ b/sysreqs/zlib.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "zlib1g-dev",
       "OSX/brew": "zlib",
+      "PKGBUILD": "zlib",
       "RPM": "zlib-devel"
     }
   }


### PR DESCRIPTION
Greetings!

I put together a PR to extend sysreqsdb to support Arch Linux and its derivatives that use [PKGBUILD](https://wiki.archlinux.org/index.php/PKGBUILD) files.

Few quick notes:

- In Arch, most libraries include their development headers, which is why you won't see any `xx-devel` packages.
- Some of the packages (e.g. [bowtie2](https://aur.archlinux.org/packages/bowtie2/)) are part of a widely-used community repo ([AUR](https://aur.archlinux.org/)). They use the same PKGBUILD format as normal arch packages though and often packages that start out on the community repo end up migrating to the officially-maintained core/extra repos.
- I'm pretty sure 99% of the arch dependencies added should refer to the correct package and work as-expected. I did not test all of them, however, so it's possible there are some invalid ones as well. If users flag these though, I/others can fix the issues as they arise.

Thanks for your work on this useful package!

Cheers,
Keith