### PR TITLE
Adds librabbitmq/rabbitmq-c.

### DIFF
--- a/sysreqs/librabbitmq.json
+++ b/sysreqs/librabbitmq.json
@@ -1,0 +1,11 @@
+{
+  "librabbitmq": {
+    "sysreqs": "librabbitmq",
+    "platforms": {
+       "DEB": "librabbitmq-dev",
+       "PKGBUILD": "librabbitmq-c",
+       "OSX/brew": "rabbitmq-c",
+       "RPM": "librabbitmq-devel"
+    }
+  }
+}


### PR DESCRIPTION
This is required for the [longears](https://github.com/atheriel/longears) package (currently GitHub-only).

I believe these are the correct packages on each platform:

- `DEB`: [librabbitmq-dev](https://packages.debian.org/buster/librabbitmq-dev)
- `PKGBUILD`: [librabbitmq-c](https://www.archlinux.org/packages/community/x86_64/librabbitmq-c/)
- `OSX/brew`: [rabbitmq-c](https://formulae.brew.sh/formula/rabbitmq-c)
- `RPM`: [librabbitmq-devel](https://apps.fedoraproject.org/packages/librabbitmq-devel)