### PR TITLE
Update v8 and proj for RPM

### DIFF
--- a/sysreqs/libproj.json
+++ b/sysreqs/libproj.json
@@ -5,7 +5,7 @@
       "DEB": "libproj-dev",
       "PKGBUILD": "proj",
       "OSX/brew": "proj",
-      "RPM": "proj-devel proj-epsg proj-nad"
+      "RPM": "proj-devel proj"
     }
   }
 }

--- a/sysreqs/v8.json
+++ b/sysreqs/v8.json
@@ -5,7 +5,7 @@
       "DEB": "libv8-dev",
       "OSX/brew": "v8",
       "PKGBUILD": "v8",
-      "RPM": "v8-314-devel"
+      "RPM": "v8-devel"
     }
   }
 }


### PR DESCRIPTION
While working on my docker image for R geospatial on various platforms for [my thesis](https://github.com/ismailsunni/dockeRs), I found out that `v8` and `proj` are outdated (at least for Fedora 30 and 32). This PR fixes those updates.