### PR TITLE
Update mapping for mysql-client and Debian and Fedora

### DIFF
--- a/sysreqs/mysql-client.json
+++ b/sysreqs/mysql-client.json
@@ -21,10 +21,16 @@
           "buildtime": "libmysqlclient-dev"
         },
         {
-          "buildtime": "libmariadb-client-lgpl-dev",
+          "distribution": "Debian",
+          "releases": ["jessie"],
+          "runtime": "libmariadb-client-lgpl-dev"
+        },
+        {
+          "buildtime": "libmariadb-dev",
           "runtime": "libmariadb2"
         }
       ],
+      "RPM": "mariadb-devel",
       "PKGBUILD": "mariadb-clients",
       "OSX/brew": "mariadb-connector-c"
     }

--- a/sysreqs/mysql-client.json
+++ b/sysreqs/mysql-client.json
@@ -15,6 +15,12 @@
           "buildtime": "libmysqlclient-dev"
         },
         {
+          "distribution": "Ubuntu",
+          "releases": ["xenial"],
+          "runtime": "libmariadb2",
+          "buildtime": "libmariadb-client-lgpl-dev"
+        },
+        {
           "distribution": "Debian",
           "releases": ["squeeze", "wheezy"],
           "runtime": "libmysqlclient18",
@@ -23,7 +29,8 @@
         {
           "distribution": "Debian",
           "releases": ["jessie"],
-          "runtime": "libmariadb-client-lgpl-dev"
+          "runtime": "libmariadb2",
+          "buildtime": "libmariadb-client-lgpl-dev"
         },
         {
           "buildtime": "libmariadb-dev",


### PR DESCRIPTION
It looks like there were some changes in which packages were available for more recent Debian releases. The package `libmariadb-client-lgpl-dev` was removed after the stretch release (and even in stretch it was a virtual package) for buster and up, `libmariadb-dev` appears to be the [appropriate dependency](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libmariadb-dev). This is true for [Ubuntu bionic and up as well](https://packages.ubuntu.com/search?keywords=libmariadb-dev). I've made sure to include the older releases (Jessie and Xenial) in case those are being used still.

An example of the r-hub failure this change should resolve: https://builder.r-hub.io/status/dittodb_0.1.0.tar.gz-60a5f1f938a84d83b51e8d654e956ecd#L75

I also included in this an addition for Fedora (which is the same as #72 ) I'm happy to take out the Fedora change from this if it's preferable to use #72 or to close #72 if doing all of these at once is easier.