### PR TITLE
add voro++

### DIFF
--- a/sysreqs/voro++.json
+++ b/sysreqs/voro++.json
@@ -1,0 +1,11 @@
+{
+  "voro++": {
+    "sysreqs": "voro++",
+    "platforms": {
+      "DEB": "voro++",
+      "OSX/brew": "voro++",
+      "PKGBUILD": "voro++",
+      "RPM": "voro++"
+    }
+  }
+}


### PR DESCRIPTION
[3D Voronoi cell software library](http://math.lbl.gov/voro++/)

I don't know if such specific packages are accepted, but I use it in this package [here](https://github.com/nevrome/bleiglas) and the [rOpenSci packaging guide](https://devguide.ropensci.org/building.html) suggests to make a PR here in case of a new system dependency.
