### PR TITLE
Add blender to sysreqs

### DIFF
--- a/sysreqs/blender.json
+++ b/sysreqs/blender.json
@@ -1,0 +1,14 @@
+{
+  "blender": {
+    "sysreqs": "blender",
+    "platforms": {
+      "DEB": "blender",
+      "PKGBUILD": "blender",
+      "Windows": {
+        "64bit": [
+          "https://www.blender.org/download/Blender2.91/blender-2.91.0-windows64.msi/"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds [Blender](blender.org/) to the database. 