### PR TITLE
add infernal (DEB)

### DIFF
--- a/sysreqs/infernal.json
+++ b/sysreqs/infernal.json
@@ -1,0 +1,8 @@
+{
+  "infernal": {
+    "sysreqs": "infernal",
+    "platforms": {
+        "DEB": "infernal"
+    }
+  }
+}


### PR DESCRIPTION
For use in the [inferrnal](https://github.com/brendanf/inferrnal) package.

The requirement is also available for OSX oh homebrew, but requires tapping a keg:

```
brew tap brewsci/bio
brew install infernal
```

Is there any way to specify this in sysreqsdb?