### PR TITLE
Add librrd

### DIFF
--- a/sysreqs/rrd.json
+++ b/sysreqs/rrd.json
@@ -1,0 +1,11 @@
+{
+  "librrd": {
+    "sysreqs": "librrd",
+    "platforms": {
+       "DEB": "librrd-dev",
+       "OSX/brew": "rrdtool",
+       "RPM": "rrdtool-devel",
+       "CSW": "rrdtool"
+    }
+  }
+}


### PR DESCRIPTION
Add information for `librrd`, required to build the `rrd` package.

Linked issue: https://github.com/andrie/rrd/issues/12