### PR TITLE
Add exception for DESeq2

### DIFF
--- a/cran/DESeq2.json
+++ b/cran/DESeq2.json
@@ -1,0 +1,3 @@
+{
+    "DESeq2": [ "openssl" ]
+}


### PR DESCRIPTION
@gaborcsardi Based on the correspondence in the GH Issue here: https://github.com/r-hub/rhub-linux-builders/issues/58

I need DESeq2 to install openssl as well, so I went ahead and added the file exception as you had done previously. Let me know if this works and merge the request if I did it right!