### PR TITLE
Add libxml2 exception for DESeq2

### DIFF
--- a/cran/DESeq2.json
+++ b/cran/DESeq2.json
@@ -1,3 +1,3 @@
 {
-    "DESeq2": [ "openssl" ]
+    "DESeq2": [ "openssl", "libxml2" ]
 }

--- a/cran/DESeq2.json
+++ b/cran/DESeq2.json
@@ -1,3 +1,3 @@
 {
-    "DESeq2": [ "openssl", "libxml2" ]
+    "DESeq2": [ "openssl" ]
 }

--- a/cran/DESeq2.json
+++ b/cran/DESeq2.json
@@ -1,0 +1,3 @@
+{
+    "DESeq2": [ "openssl" ]
+}


### PR DESCRIPTION
@gaborcsardi sorry for another pull request, but I need this exception added as well.

Don't be scared by the amount of commits, if you look at them you'll see I forgot to fetch upstream before I committed the change so the commits are the following:
1. Add initial openssl exception. (Already merged)
2. Add libxml2 exception.
3. Revert commit in point 2.
4. Fetch upstream from this branch.
5. Re-add libxml2 exception.

The only thing changed in code is adding the `libxml2` exception to DESeq2.