### PR TITLE
Add osmium-tool

### DIFF
--- a/sysreqs/osmium-tool.json
+++ b/sysreqs/osmium-tool.json
@@ -1,0 +1,11 @@
+{
+  "osmium-tool": {
+    "sysreqs": "osmium-tool",
+    "platforms": {
+      "DEB": "osmium-tool",
+      "PKGBUILD": "osmium-tool",
+      "RPM": "osmium-tool",
+      "OSX/brew": "osmium-tool"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for [osmium-tool](https://osmcode.org/osmium-tool/) (for the sake of my rather janky package [{parochial}](https://github.com/stupidpupil/parochial) ).

I don't know if there are 'notability' requirements on this project - if there are, I entirely understand if this doesn't meet them!
