### PR TITLE
update to Ubuntu release-specific system requirements

### DIFF
--- a/sysreqs/libdb_stl.json
+++ b/sysreqs/libdb_stl.json
@@ -5,15 +5,15 @@
       "DEB": [
         {
           "distribution": "Ubuntu",
-          "releases": ["bionic", "cosmic", "artful", "xenial", "trusty"],
-          "runtime": "libdb5.3-stl-dev",
-          "buildtime": "libdb5.3-stl"
+          "releases": ["bionic", "cosmic", "artful", "xenial", "trusty", "focal", "jammy"],
+          "runtime": "libdb5.3-stl",
+          "buildtime": "libdb5.3-stl-dev"
         },
         {
           "distribution": "Debian",
           "releases": ["jessie", "stretch", "buster", "sid"],
-          "runtime": "libdb5.3-stl-dev",
-          "buildtime": "libdb5.3-stl"
+          "runtime": "libdb5.3-stl",
+          "buildtime": "libdb5.3-stl-dev"
         }
       ],
       "OSX/brew": "berkeley-db",

--- a/sysreqs/libgsl.json
+++ b/sysreqs/libgsl.json
@@ -15,6 +15,18 @@
           "buildtime": "libgsl-dev"
         },
         {
+          "distribution": "Ubuntu",
+          "releases": ["bionic", "focal"],
+          "runtime": "libgsl23",
+          "buildtime": "libgsl-dev"
+        },        
+        {
+          "distribution": "Ubuntu",
+          "releases": ["jammy"],
+          "runtime": "libgsl27",
+          "buildtime": "libgsl-dev"
+        },
+        {
           "distribution": "Debian",
           "releases": ["squeeze", "wheezy", "jessie"],
           "runtime": "libgsl0ldbl",

--- a/sysreqs/mysql-client.json
+++ b/sysreqs/mysql-client.json
@@ -21,6 +21,12 @@
           "buildtime": "libmysqlclient-dev"
         },
         {
+          "distribution": "Ubuntu",
+          "releases": ["bionic", "focal", "jammy"],
+          "runtime": "libmariadb3",
+          "buildtime": "libmysqlclient-dev"
+        },
+        {
           "distribution": "Debian",
           "releases": ["squeeze", "wheezy"],
           "runtime": "libmysqlclient18",


### PR DESCRIPTION
I noticed that for 3 system requirements there are release-specific system-requirements. All of these are outdated. Therefore I have updated the json files to support the most recent Ubuntu LTS releases.