### PR TITLE
Add libtool

### DIFF
--- a/sysreqs/libtool.json
+++ b/sysreqs/libtool.json
@@ -1,0 +1,11 @@
+{
+  "libtool": {
+    "sysreqs": "libtool",
+    "platforms": {
+      "DEB": "libtool",
+      "RPM": "libtool",
+      "OSX/brew": "libtool",
+      "PKGBUILD": "libtool"
+    }
+  }
+}


### PR DESCRIPTION
As automake is already an available option, I think it is reasonable to also add libtool. While R does come bundled with libtool (at least on posix systems), it does not function with some autotools setups ([openmpi/hwloc](https://www.github.com/open-mpi/hwloc), in my case) do not work without a re-run of libtoolize, a script typically distributed with libtool but /not/ included with R.